### PR TITLE
Added missing index

### DIFF
--- a/Sources/UrlRouter.swift
+++ b/Sources/UrlRouter.swift
@@ -204,9 +204,9 @@ open class UrlRouter {
 						let range: NSRange
 
 						#if swift(>=4.0)
-							range = match.range(at: 1)
+							range = match.range(at: i)
 						#else
-							range = match.rangeAt(1)
+							range = match.rangeAt(i)
 						#endif
 
 						if range.location != NSNotFound {


### PR DESCRIPTION
The missing index caused every value of parameter to be equal to the first parameter value.